### PR TITLE
Switched to using /usr/libexec rather than /usr/bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(lubuntu-installer-prompt PRIVATE Qt6::Widgets)
 
 qt_finalize_executable(lubuntu-installer-prompt)
 
-install(TARGETS lubuntu-installer-prompt DESTINATION bin)
-install(PROGRAMS "scripts/lubuntu-installer" DESTINATION bin)
+install(TARGETS lubuntu-installer-prompt DESTINATION libexec)
+install(PROGRAMS "scripts/lubuntu-installer" DESTINATION libexec)
 install(FILES "img/background.png" DESTINATION share/lubuntu/installer-prompt)
 install(FILES "lubuntu-installer-prompt.desktop" DESTINATION /etc/xdg/xdg-Lubuntu/autostart)

--- a/src/installerprompt.cpp
+++ b/src/installerprompt.cpp
@@ -45,7 +45,7 @@ void InstallerPrompt::tryLubuntu()
 void InstallerPrompt::installLubuntu()
 {
     QProcess *calamares = new QProcess(this);
-    calamares->start("/usr/bin/lubuntu-installer");
+    calamares->start("/usr/libexec/lubuntu-installer");
 }
 
 InstallerPrompt::~InstallerPrompt()


### PR DESCRIPTION
This was a change suggested by vorlon on #ubuntu-devel to avoid having to use the manpage overrides in the packaging. It simply switches the installation directory for the main binaries to /usr/libexec rather than /usr/bin, plus a slight mod in the code to ensure that the lubuntu-installer binary can be launched by lubuntu-installer-prompt now that it has been moved.